### PR TITLE
Output html class with photo-size used

### DIFF
--- a/wp-instagram-widget.php
+++ b/wp-instagram-widget.php
@@ -122,7 +122,7 @@ class null_instagram_widget extends WP_Widget {
 				if ( $images_only = apply_filters( 'wpiw_images_only', FALSE ) )
 					$media_array = array_filter( $media_array, array( $this, 'images_only' ) );
 
-				?><ul class="instagram-pics"><?php
+				?><ul class="instagram-pics size-<?php echo $instance['size']; ?>"><?php
 				foreach ($media_array as $item) {
 					echo '<li><a href="'. esc_url( $item['link'] ) .'" target="'. esc_attr( $target ) .'"><img src="'. esc_url($item[$size]['url']) .'"  alt="'. esc_attr( $item['description'] ) .'" title="'. esc_attr( $item['description'] ).'"/></a></li>';
 				}


### PR DESCRIPTION
Hi Scott,

I really like the simplicity and effectiveness of the plugin.
However, I was in need of styling it differently based on the image-size picked, so I added the `class` in the `<ul>` output. 

I figured it would be better to make this pull-request instead of a 'feature-request'.
Please, pardon my rudeness, if all this is not-so-cool in any way.

It would be totally ok with me if you would implement this 'feature' on your own and close this pull-request.

All the best,
Matija