### PR TITLE
Allow description in "new" style data when available.

### DIFF
--- a/wp-instagram-widget.php
+++ b/wp-instagram-widget.php
@@ -218,8 +218,13 @@ class null_instagram_widget extends WP_Widget {
 							$type = 'image';
 						}
 
+						$caption = __( 'Instagram Image', 'wpiw' );
+						if (!empty( $image['caption'] )) {
+							$caption = $image['caption'];
+						}
+
 						$instagram[] = array(
-							'description'   => __( 'Instagram Image', 'wpiw' ),
+							'description'   => $caption,
 							'link'		  	=> '//instagram.com/p/' . $image['code'],
 							'time'		  	=> $image['date'],
 							'comments'	  	=> $image['comments']['count'],


### PR DESCRIPTION
This pull request expands on #21. It seems like there might be situations where the `caption` is available. I'm not sure when. This pull request will allow `description` to be set when it is available, otherwise it will use a default value.

I wasn't able to find any users where the caption was not available, but it seems to be for this account:
https://instagram.com/gabrielcoffee