### PR TITLE
Validate $instance['size'] before using it.

### DIFF
--- a/wp-instagram-widget.php
+++ b/wp-instagram-widget.php
@@ -90,7 +90,10 @@ class null_instagram_widget extends WP_Widget {
 				$aclass = esc_attr( apply_filters( 'wpiw_a_class', '' ) );
 				$imgclass = esc_attr( apply_filters( 'wpiw_img_class', '' ) );
 
-				?><ul class="instagram-pics instagram-size-<?php echo esc_attr( $instance['size'] ); ?>"><?php
+				// check for empty size
+				$sizeclass = ( !empty( $instance['size'] ) ? 'instagram-size-' . esc_attr( $instance['size'] ) : 'instagram-size-default' );
+
+				?><ul class="instagram-pics <?php echo $sizeclass; ?>"><?php
 				foreach ( $media_array as $item ) {
 					// copy the else line into a new file (parts/wp-instagram-widget.php) within your theme and customise accordingly
 					if ( locate_template( 'parts/wp-instagram-widget.php' ) != '' ) {


### PR DESCRIPTION
This is a small fix for wp-instagram-widget 1.7 that validates `$instance['size']` before using it. 

An upgrade from 1.6 -> 1.7 triggers the following PHP notice, as `$instance['size']` is undefined:

> Notice: Undefined index: size in wp-content/plugins/wp-instagram-widget/wp-instagram-widget.php:93