### PR TITLE
Added a filter to change the path of the template file

### DIFF
--- a/wp-instagram-widget.php
+++ b/wp-instagram-widget.php
@@ -89,7 +89,7 @@ class null_instagram_widget extends WP_Widget {
 				$liclass = apply_filters( 'wpiw_item_class', '' );
 				$aclass = apply_filters( 'wpiw_a_class', '' );
 				$imgclass = apply_filters( 'wpiw_img_class', '' );
-        $template_part = apply_filters( 'wpiw_template_part', 'parts/wp-instagram-widget.php' );
+				$template_part = apply_filters( 'wpiw_template_part', 'parts/wp-instagram-widget.php' );
 
 				?><ul class="<?php echo esc_attr( $ulclass ); ?>"><?php
 				foreach ( $media_array as $item ) {

--- a/wp-instagram-widget.php
+++ b/wp-instagram-widget.php
@@ -89,12 +89,13 @@ class null_instagram_widget extends WP_Widget {
 				$liclass = apply_filters( 'wpiw_item_class', '' );
 				$aclass = apply_filters( 'wpiw_a_class', '' );
 				$imgclass = apply_filters( 'wpiw_img_class', '' );
+        $template_part = apply_filters( 'wpiw_template_part', 'parts/wp-instagram-widget.php' );
 
 				?><ul class="<?php echo esc_attr( $ulclass ); ?>"><?php
 				foreach ( $media_array as $item ) {
 					// copy the else line into a new file (parts/wp-instagram-widget.php) within your theme and customise accordingly
-					if ( locate_template( 'parts/wp-instagram-widget.php' ) != '' ) {
-						include locate_template( 'parts/wp-instagram-widget.php' );
+					if ( locate_template( $template_part ) != '' ) {
+						include locate_template( $template_part );
 					} else {
 						echo '<li class="'. esc_attr( $liclass ) .'"><a href="'. esc_url( $item['link'] ) .'" target="'. esc_attr( $target ) .'"  class="'. esc_attr( $aclass ) .'"><img src="'. esc_url( $item[$size] ) .'"  alt="'. esc_attr( $item['description'] ) .'" title="'. esc_attr( $item['description'] ).'"  class="'. esc_attr( $imgclass ) .'"/></a></li>';
 					}


### PR DESCRIPTION
I have an existing theme. In order to alter HTML markup, I needed to create a new directory `parts` just to override the default markup. But I have a different folder structure in my theme and `parts` doesn't really fit into it. Thus, created a filter to change the path of the template file. Default is still `parts/wp-instagram-widget.php`.

It would be great if you could incorporate this into WordPress version of the plugin.