### PR TITLE
Issue #63: scrape_instagram fetches more pages

### DIFF
--- a/wp-instagram-widget.php
+++ b/wp-instagram-widget.php
@@ -177,11 +177,12 @@ Class null_instagram_widget extends WP_Widget {
 	}
 
 	// based on https://gist.github.com/cosmocatalano/4544576.
-	function scrape_instagram( $username ) {
+	function scrape_instagram( $username, $max_id = null ) {
 
 		$username = trim( strtolower( $username ) );
+		$max_id   = (int)$max_id;
 
-		$transient_key = 'instagram-a6-'.sanitize_title_with_dashes( $username );
+		$transient_key = 'instagram-a6-'.sanitize_title_with_dashes( $username ).'-max-id-'.$max_id;
 
 		if ( false === ( $instagram = get_transient( $transient_key ) ) ) {
 
@@ -193,6 +194,10 @@ Class null_instagram_widget extends WP_Widget {
 				default:
 					$url = 'https://instagram.com/' . str_replace( '@', '', $username );
 					break;
+			}
+
+			if ( $max_id ) {
+				$url .= '?max_id='.$max_id;
 			}
 
 			$remote = wp_remote_get( $url );
@@ -268,6 +273,7 @@ Class null_instagram_widget extends WP_Widget {
 					'small'			=> $image['small'],
 					'large'			=> $image['large'],
 					'original'		=> $image['display_src'],
+					'id'			=> $image['id'],
 					'type'		  	=> $type,
 				);
 			} // End foreach().

--- a/wp-instagram-widget.php
+++ b/wp-instagram-widget.php
@@ -181,7 +181,9 @@ Class null_instagram_widget extends WP_Widget {
 
 		$username = trim( strtolower( $username ) );
 
-		if ( false === ( $instagram = get_transient( 'instagram-a6-' . sanitize_title_with_dashes( $username ) ) ) ) {
+		$transient_key = 'instagram-a6-'.sanitize_title_with_dashes( $username );
+
+		if ( false === ( $instagram = get_transient( $transient_key ) ) ) {
 
 			switch ( substr( $username, 0, 1 ) ) {
 				case '#':
@@ -273,7 +275,7 @@ Class null_instagram_widget extends WP_Widget {
 			// do not set an empty transient - should help catch private or empty accounts.
 			if ( ! empty( $instagram ) ) {
 				$instagram = base64_encode( serialize( $instagram ) );
-				set_transient( 'instagram-a6-' . sanitize_title_with_dashes( $username ), $instagram, apply_filters( 'null_instagram_cache_time', HOUR_IN_SECONDS * 2 ) );
+				set_transient( $transient_key, $instagram, apply_filters( 'null_instagram_cache_time', HOUR_IN_SECONDS * 2 ) );
 			}
 		}
 


### PR DESCRIPTION
The scraping method can now fetch more that one page:

```php
$need_pages = 4;
$media_array = [];
$last_media_id = null;
$widget = new null_instagram_widget();

for($i = 0; $i < $need_pages; ++ $i) {
    $media_array = array_merge($media_array, $widget->scrape_instagram('@some_user', $last_media_id));
    $last_media_id = $media_array[count($media_array) - 1]['id'];
}
```

Fixes #63 