### PR TITLE
Add filter for adding img attributes

### DIFF
--- a/wp-instagram-widget.php
+++ b/wp-instagram-widget.php
@@ -97,6 +97,7 @@ Class null_instagram_widget extends WP_Widget {
 				$liclass = apply_filters( 'wpiw_item_class', '' );
 				$aclass = apply_filters( 'wpiw_a_class', '' );
 				$imgclass = apply_filters( 'wpiw_img_class', '' );
+				$imgattribs = apply_filters( 'wpiw_img_attribs', '' );
 				$template_part = apply_filters( 'wpiw_template_part', 'parts/wp-instagram-widget.php' );
 
 				?><ul class="<?php echo esc_attr( $ulclass ); ?>"><?php
@@ -105,7 +106,7 @@ Class null_instagram_widget extends WP_Widget {
 					if ( locate_template( $template_part ) !== '' ) {
 						include locate_template( $template_part );
 					} else {
-						echo '<li class="' . esc_attr( $liclass ) . '"><a href="' . esc_url( $item['link'] ) . '" target="' . esc_attr( $target ) . '"  class="' . esc_attr( $aclass ) . '"><img src="' . esc_url( $item[$size] ) . '"  alt="' . esc_attr( $item['description'] ) . '" title="' . esc_attr( $item['description'] ) . '"  class="' . esc_attr( $imgclass ) . '"/></a></li>';
+						echo '<li class="' . esc_attr( $liclass ) . '"><a href="' . esc_url( $item['link'] ) . '" target="' . esc_attr( $target ) . '"  class="' . esc_attr( $aclass ) . '"><img src="' . esc_url( $item[$size] ) . '"  alt="' . esc_attr( $item['description'] ) . '" title="' . esc_attr( $item['description'] ) . '"  class="' . esc_attr( $imgclass ) . ' ' . esc_attr( $imgattribs ) . '"/></a></li>';
 					}
 				}
 				?></ul><?php


### PR DESCRIPTION
usage:

add_filter( 'wpiw_img_attribs', 'my_pinterest_nopin' );
function my_pinterest_nopin( $attributes ){
	$attributes .= 'data-pin-nopin="true"';
	return $attributes;
}

We don't want visitors accidentally pinning the image loaded from Instagram in the widget - it's better if they pin the original. Remove the WPIW images from being pinnable.

See: https://www.wptasty.com/blog/nopin-images

https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes